### PR TITLE
removed index from evt

### DIFF
--- a/doc/news/DM-45809.misc.rst
+++ b/doc/news/DM-45809.misc.rst
@@ -1,0 +1,1 @@
+Removed index from event, which isn't accepted in the xml and isn't needed

--- a/python/lsst/ts/ledprojector/ledprojector_csc.py
+++ b/python/lsst/ts/ledprojector/ledprojector_csc.py
@@ -202,7 +202,6 @@ class LEDProjectorCsc(salobj.ConfigurableCsc):
         led_serials = await self.led_controller.switch_all_leds_off()
         for sn in led_serials:
             await self.evt_ledState.set_write(
-                index=0,
                 serialNumber=sn,
                 ledBasicState=self.led_controller.channels[sn].status,
                 value=self.led_controller.channels[sn].dac_value,
@@ -227,7 +226,6 @@ class LEDProjectorCsc(salobj.ConfigurableCsc):
         led_serials = await self.led_controller.switch_all_leds_on()
         for sn in led_serials:
             await self.evt_ledState.set_write(
-                index=0,
                 serialNumber=sn,
                 ledBasicState=self.led_controller.channels[sn].status,
                 value=self.led_controller.channels[sn].dac_value,


### PR DESCRIPTION
In testing the LEDProjector CSC, found there is an error in the CSC that lists index for publshing and event, which doesn’t accept it in the xml.