### PR TITLE
Add ledsOn event publishing

### DIFF
--- a/doc/news/OSW-2379.feature.rst
+++ b/doc/news/OSW-2379.feature.rst
@@ -1,0 +1,1 @@
+Added publishing of the ``ledsOn`` event with comma-delimited LED serial numbers and DAC values for LEDs that are currently on.

--- a/python/lsst/ts/ledprojector/led_controller.py
+++ b/python/lsst/ts/ledprojector/led_controller.py
@@ -370,6 +370,26 @@ additionalProperties: false
         partial = functools.partial(func, *args, **kwargs)
         return await asyncio.to_thread(partial)
 
+    def get_led_channels_on(self) -> tuple[str, str]:
+        """Return LEDs that are on and their DAC values.
+
+        Returns
+        -------
+        serial_numbers : `str`
+            Comma-delimited serial numbers for LEDs whose cached state is ON.
+        values : `str`
+            Comma-delimited cached DAC values for the same LEDs. The order
+            matches ``serial_numbers`` and the configured LED order.
+        """
+        channels_on = [
+            channel
+            for led_name in self.led_names
+            if (channel := self.channels[led_name]).status is LEDBasicState.ON
+        ]
+        return ",".join(channel.serial for channel in channels_on), ",".join(
+            str(channel.dac_value) for channel in channels_on
+        )
+
     def get_state(
         self,
         identifier: str | int,

--- a/python/lsst/ts/ledprojector/ledprojector_csc.py
+++ b/python/lsst/ts/ledprojector/ledprojector_csc.py
@@ -207,6 +207,7 @@ class LEDProjectorCsc(salobj.ConfigurableCsc):
                 ledBasicState=self.led_controller.channels[sn].status,
                 value=self.led_controller.channels[sn].dac_value,
             )
+        await self.update_leds_on()
 
     async def do_switchAllOn(self, data: types.SimpleNamespace) -> None:
         """Switch on all LEDs.
@@ -231,6 +232,7 @@ class LEDProjectorCsc(salobj.ConfigurableCsc):
                 ledBasicState=self.led_controller.channels[sn].status,
                 value=self.led_controller.channels[sn].dac_value,
             )
+        await self.update_leds_on()
 
     async def switch_leds(self, identifiers: List[Union[str, int]], on_off: LEDBasicState) -> None:
         """Switch multiple LEDs at once.
@@ -287,6 +289,7 @@ class LEDProjectorCsc(salobj.ConfigurableCsc):
                 ledBasicState=self.led_controller.channels[sn].status,
                 value=self.led_controller.channels[sn].dac_value,
             )
+        await self.update_leds_on()
 
     async def do_adjustAllDACPower(self, data: types.SimpleNamespace) -> None:
         """Adjust voltage on all DAC Channels.
@@ -320,6 +323,8 @@ class LEDProjectorCsc(salobj.ConfigurableCsc):
                 ledBasicState=channel.status,
                 value=channel.dac_value,
             )
+
+        await self.update_leds_on()
 
     async def do_switchOn(self, data: types.SimpleNamespace) -> None:
         """Switch on one or more LEDs.
@@ -355,6 +360,8 @@ class LEDProjectorCsc(salobj.ConfigurableCsc):
             )
             await self.evt_ledState.write()
 
+        await self.update_leds_on()
+
     async def do_switchOff(self, data: types.SimpleNamespace) -> None:
         """Switch off one or more specific led.
 
@@ -379,6 +386,19 @@ class LEDProjectorCsc(salobj.ConfigurableCsc):
                 ledBasicState=self.led_controller.channels[sn].status,
             )
             await self.evt_ledState.write()
+
+        await self.update_leds_on()
+
+    async def update_leds_on(self) -> None:
+        """Calculate and publish the ledsOn event if it exists."""
+        if self.led_controller is None:
+            raise RuntimeError("Labjack is not connected.")
+        channels, values = self.led_controller.get_led_channels_on()
+        # TODO OSW-2435 Remove once compatible XML is released.
+        if hasattr(self, "evt_ledsOn"):
+            await self.evt_ledsOn.set_write(serialNumbers=channels, dacValues=values)
+        else:
+            self.log.warning("Cannot publish evt_ledsOn with current XML.")
 
 
 def run_ledprojector() -> None:

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -43,6 +43,11 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             simulation_mode=simulation_mode,
         )
 
+    # TODO OSW-2435 Remove once compatible XML is released.
+    def require_leds_on_event(self) -> None:
+        if not hasattr(self.remote, "evt_ledsOn"):
+            self.skipTest("evt_ledsOn is not available in this XML version.")
+
     async def test_standard_state_transitions(self) -> None:
         async with self.make_csc(
             initial_state=salobj.State.STANDBY,
@@ -132,6 +137,113 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 assert value == 0
             except AttributeError:
                 pass
+
+    async def test_switch_on_publishes_leds_on_event(self) -> None:
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED,
+            config_dir=TEST_CONFIG_DIR,
+            simulation_mode=1,
+        ):
+            self.require_leds_on_event()
+            assert self.csc.led_controller is not None
+            self.csc.led_controller.channels["M375L4"].dac_value = 1.5
+
+            # TODO DM-44713 Remove when XML v21 is released.
+            try:
+                self.remote.cmd_switchOn.set(serialNumbers="M375L4")
+            except AttributeError:
+                self.remote.cmd_switchOn.set(serialNumber="M375L4")
+
+            await self.remote.cmd_switchOn.start(timeout=SHORT_TIMEOUT)
+
+            leds_on = await self.assert_next_sample(
+                topic=self.remote.evt_ledsOn,
+            )
+            assert leds_on.serialNumbers == "M375L4"
+            assert leds_on.dacValues == "1.5"
+
+    async def test_switch_on_publishes_all_leds_on_event_values(self) -> None:
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED,
+            config_dir=TEST_CONFIG_DIR,
+            simulation_mode=1,
+        ):
+            self.require_leds_on_event()
+            assert self.csc.led_controller is not None
+            self.csc.led_controller.channels["M375L4"].dac_value = 1.5
+            self.csc.led_controller.channels["M505L4"].dac_value = 2.75
+            self.csc.led_controller.channels["M565L4"].dac_value = 4.0
+
+            self.csc.led_controller._set_state("M565L4", LEDBasicState.OFF)
+
+            # TODO DM-44713 Remove when XML v21 is released.
+            try:
+                self.remote.cmd_switchOn.set(serialNumbers="M375L4,M505L4")
+            except AttributeError:
+                self.remote.cmd_switchOn.set(serialNumber="M375L4,M505L4")
+
+            await self.remote.cmd_switchOn.start(timeout=SHORT_TIMEOUT)
+
+            leds_on = await self.assert_next_sample(
+                topic=self.remote.evt_ledsOn,
+            )
+            assert leds_on.serialNumbers == "M375L4,M505L4"
+            assert leds_on.dacValues == "1.5,2.75"
+
+    async def test_switch_off_publishes_leds_on_event(self) -> None:
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED,
+            config_dir=TEST_CONFIG_DIR,
+            simulation_mode=1,
+        ):
+            self.require_leds_on_event()
+            assert self.csc.led_controller is not None
+            self.csc.led_controller.channels["M375L4"].dac_value = 1.5
+            self.csc.led_controller.channels["M505L4"].dac_value = 2.75
+            self.csc.led_controller._set_state("M375L4", LEDBasicState.ON)
+            self.csc.led_controller._set_state("M505L4", LEDBasicState.ON)
+            update_leds_on_mock = mock.AsyncMock(wraps=self.csc.update_leds_on)
+            self.csc.update_leds_on = update_leds_on_mock
+
+            # TODO DM-44713 Remove when XML v21 is released.
+            try:
+                self.remote.cmd_switchOff.set(serialNumbers="M375L4")
+            except AttributeError:
+                self.remote.cmd_switchOff.set(serialNumber="M375L4")
+
+            await self.remote.cmd_switchOff.start(timeout=SHORT_TIMEOUT)
+
+            leds_on = await self.assert_next_sample(
+                topic=self.remote.evt_ledsOn,
+            )
+            update_leds_on_mock.assert_awaited_once()
+            assert leds_on.serialNumbers == "M505L4"
+            assert leds_on.dacValues == "2.75"
+
+    async def test_adjust_all_dac_power_publishes_leds_on_event(self) -> None:
+        async with self.make_csc(
+            initial_state=salobj.State.ENABLED,
+            config_dir=TEST_CONFIG_DIR,
+            simulation_mode=1,
+        ):
+            self.require_leds_on_event()
+            assert self.csc.led_controller is not None
+            self.csc.led_controller._set_state("M375L4", LEDBasicState.ON)
+            self.csc.led_controller._set_state("M505L4", LEDBasicState.ON)
+            self.csc.led_controller._set_state("M565L4", LEDBasicState.OFF)
+            update_leds_on_mock = mock.AsyncMock(wraps=self.csc.update_leds_on)
+            self.csc.update_leds_on = update_leds_on_mock
+
+            self.remote.cmd_adjustAllDACPower.set(dacValue=3.25)
+
+            await self.remote.cmd_adjustAllDACPower.start(timeout=SHORT_TIMEOUT)
+
+            leds_on = await self.assert_next_sample(
+                topic=self.remote.evt_ledsOn,
+            )
+            update_leds_on_mock.assert_awaited_once()
+            assert leds_on.serialNumbers == "M375L4,M505L4"
+            assert leds_on.dacValues == "3.25,3.25"
 
     async def test_enable_retries_controller_connection(self) -> None:
         open_attempts = 0

--- a/tests/test_led_controller.py
+++ b/tests/test_led_controller.py
@@ -125,6 +125,25 @@ class DataClientTestCase(unittest.IsolatedAsyncioTestCase):
         led_client._set_state("M375L4", LEDBasicState.OFF)
         assert led_client.get_state("DIO1") is LEDBasicState.OFF
 
+    async def test_get_led_channels_on(self) -> None:
+        config = self.get_config("config.yaml")
+        led_client = ledprojector.LEDController(
+            config=config,
+            log=self.log,
+            simulate=True,
+        )
+
+        assert led_client.get_led_channels_on() == ("", "")
+
+        led_client._set_state("M375L4", LEDBasicState.ON)
+        led_client.channels["M375L4"].dac_value = 1.5
+        led_client._set_state("CIO3", LEDBasicState.ON)
+        led_client.channels["CIO3"].dac_value = 2.75
+        led_client._set_state("M565L4", LEDBasicState.OFF)
+        led_client.channels["M565L4"].dac_value = 4.0
+
+        assert led_client.get_led_channels_on() == ("M375L4,M505L4", "1.5,2.75")
+
     async def test_connecting(self) -> None:
         config = self.get_config("config.yaml")
         led_client = ledprojector.LEDController(


### PR DESCRIPTION
Track the currently-on LEDs and their DAC values as comma-delimited
strings for the ledsOn event payload. Publish the event after LED switch
and DAC adjustment commands, while preserving compatibility with XML
versions that do not define the event.

Add controller and CSC tests for the helper output and ledsOn publication
from switchOn, switchOff, and adjustAllDACPower.
